### PR TITLE
fix: render in higher resolutions on devices with higher pixel densities

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -740,6 +740,7 @@ function resetRenderer() {
   renderer.outputColorSpace = THREE.LinearSRGBColorSpace;
   renderer.domElement.id = 'MAIN_RENDERER';
   renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.setPixelRatio(window.devicePixelRatio);
 
   document.body.appendChild(renderer.domElement);
 


### PR DESCRIPTION
Before this change, on devices with the display scaling set to >100% the rendered output would look blurry due to it rendering at 100%. After this change, the render is nice and sharp.