### PR TITLE
fix(ihp): Implement missing PolyRes layer

### DIFF
--- a/src/process_layers.js
+++ b/src/process_layers.js
@@ -186,6 +186,14 @@ let PROCESS_LAYERS = {
       color: [0.75, 0.35, 0.46, 1.0],
     },
     {
+      layer_number: 128,
+      layer_datatype: 0,
+      name: 'PolyRes',
+      zmin: 0.0,
+      zmax: 0.16,
+      color: [0.55, 0.2, 0.0, 1.0],
+    },
+    {
       layer_number: 6,
       layer_datatype: 0,
       name: 'Cont',


### PR DESCRIPTION
IHP SG13G2 layer `128/0` (`PolyRes`) was missing from layer definitions, meaning `rhigh` resistors were not rendering. This fixes it:

![image](https://github.com/user-attachments/assets/0a87eb0f-692b-43d7-a781-fa2bd001ca95)

Image above was generated from this URL suffix, and could be used for verification (resistor arrays seen in top-left corner of the layout): `/?model=https://algofoogle.github.io/ttihp0p3-antonalog/tinytapeout.gds&process=SG13G2` -- or if you just want to prove you can see the adjoining area in a SINGLE resistor, you could use this GDS: https://github.com/algofoogle/ttihp0p3-antonalog/blob/main/gds/rhigh.gds

NOTE: I'm not sure whether or not this also fixes other types of resistors (`rppd`, `rsil`) as I haven't used those.